### PR TITLE
DEVOPS-13339: Component Path incorrect in Summary Step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -592,7 +592,7 @@ runs:
     - name: Publish Summary or Generate GitHub Issue Description for Drift Detection
       id: summary
       shell: bash
-      working-directory: ./${{ steps.vars.outputs.component_path }}
+      working-directory: ${{ steps.vars.outputs.component_path }}
       run: |
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
           STEP_SUMMARY_FILE="${{ steps.vars.outputs.issue_file }}"


### PR DESCRIPTION
Removing the `./` qualifier in the `working-directory` configuration as the path is being incorrectly assembled. 