### PR TITLE
DEVOPS-14198: -destroy flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: "Whether to install dependencies with Aqua. If false, it is assumed that the runner already has the necessary dependencies installed. Default: 'true'"
     required: false
     default: 'true'
+  destroy:
+    description: "If true, adds '-destroy' flag to the atmos terraform plan command to generate a destroy plan. Default: 'false'"
+    required: false
+    default: 'false'
 outputs:
   summary:
     description: "Summary"
@@ -395,6 +399,7 @@ runs:
           -lock=false \
           -input=false \
           -no-color \
+          $([[ "${{ inputs.destroy }}" == "true" ]] && echo "-destroy") \
           ${atmos_pro_flags} \
         &> ${TERRAFORM_OUTPUT_FILE}
 


### PR DESCRIPTION
## what

- Adds a `destroy` input to the workflow, specifying that the component should be destroyed.
- Defaults to `false`
- Typically expects `sha` to be passed, and equal the main branch (PR branch would typically be missing the component definition by this point)

## why

- We want a way to destroy components that are being removed.

## references

[DEVOPS-14198](https://qventus.atlassian.net/browse/DEVOPS-14198)

[DEVOPS-14198]: https://qventus.atlassian.net/browse/DEVOPS-14198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ